### PR TITLE
using "callable" type instead of "mixed"

### DIFF
--- a/src/Vimeo.php
+++ b/src/Vimeo.php
@@ -12,8 +12,8 @@ class Vimeo extends Field
      * @var string
      */
     public $component = 'vimeo';
-    
-    public function __construct(string $name, ?string $attribute = null, ?mixed $resolveCallback = null)
+
+    public function __construct(string $name, ?string $attribute = null, ?callable $resolveCallback = null)
     {
         parent::__construct($name, $attribute, $resolveCallback);
         $this->withMeta([


### PR DESCRIPTION
https://www.php.net/manual/en/language.pseudo-types.php

Pseudo-types are keywords used in the PHP documentation to specify the types or values an argument can have. Please note that they are not primitives of the PHP language. So you cannot use pseudo-types as typehints in your own custom functions. 